### PR TITLE
Initial support for AWFI, PAN10M and PAN5M included

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 RUN pip3 install numpy wheel cython --no-binary numpy
 
 # Install Python dependencies
-RUN pip3 install rio-tiler==1.0a.6 lambda_proxy==0.0.4 aws-sat-api==0.0.5 --no-binary numpy -t /tmp/vendored -U
+RUN pip3 install rio-tiler==1.0a.7 lambda_proxy==0.0.4 aws-sat-api==1.0.0 --no-binary numpy -t /tmp/vendored -U
 
 # Reduce Lambda package size to fit the 250Mb limit
 # Mostly based on https://github.com/jamesandersen/aws-machine-learning-demo

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This project is based on [rio-tiler](https://github.com/mapbox/rio-tiler) python
 
 #### CBERS-4 data on AWS
 
-Hosted since late 2017 on AWS, CBERS-4 data offers an alternative to cbers and Sentinel data (https://aws.amazon.com/fr/blogs/publicsector/the-china-brazil-earth-resources-satellite-mission/).
+Hosted since late 2017, [CBERS-4 data on AWS](https://registry.opendata.aws/cbers/) offers an alternative to cbers and Sentinel data (https://aws.amazon.com/fr/blogs/publicsector/the-china-brazil-earth-resources-satellite-mission/).
 
 > China–Brazil Earth Resources Satellite 4 (CBERS-4), also known as Ziyuan I-04 or Ziyuan 1E, is a remote sensing satellite intended for operation as part of the China–Brazil Earth Resources Satellite programme between the China Centre for Resources Satellite Data and Application and Brazil's National Institute for Space Research. The fifth CBERS satellite to fly, it was successfully launched on 7 December 2014. It replaces CBERS-3 which was lost in a launch failure in December 2013.
 

--- a/app/cbers.py
+++ b/app/cbers.py
@@ -29,10 +29,11 @@ def search():
 
     path = query_args['path']
     row = query_args['row']
+    sensor = query_args['sensor']
 
-    data = list(cbers_search(path, row))
+    data = list(cbers_search(path, row, sensor))
     info = {
-        'request': {'path': path, 'row': row},
+        'request': {'path': path, 'row': row, 'sensor': sensor},
         'meta': {'found': len(data)},
         'results': data}
 

--- a/viewer/css/style.css
+++ b/viewer/css/style.css
@@ -137,6 +137,14 @@ body {
   display: inline-block;
 }
 
+.img-display-options .stoggle-group {
+  display: block;
+}
+
+.img-display-options .stoggle-group * {
+  display: inline-block;
+}
+
 .img-display-options .toggle {
   font-size: 10px;
   color: #000;

--- a/viewer/index.html
+++ b/viewer/index.html
@@ -26,20 +26,41 @@
 					<div class="list-img"></div>
 
 					<div class="img-display-options">
+						<span>Sensor</span>
+
+						<div class='stoggle-group mr18'>
+							<label class='toggle-container'>
+								<input data="MUX" checked name='stoggle' type='radio'/>
+								<div class='btn btn--stroke btn--darken50 toggle'>MUX</div>
+							</label>
+							<label class='toggle-container'>
+								<input data="AWFI" name='stoggle' type='radio' />
+								<div class='btn btn--stroke btn--darken50 toggle'>AWFI</div>
+							</label>
+							<label class='toggle-container'>
+								<input data="PAN10M" name='stoggle' type='radio' />
+								<div class='btn btn--stroke btn--darken50 toggle'>PAN10M</div>
+							</label>
+							<label class='toggle-container'>
+								<input data="PAN5M" name='stoggle' type='radio' />
+								<div class='btn btn--stroke btn--darken50 toggle'>PAN5M</div>
+							</label>
+						</div>
+
 						<span>RGB Combination </span>
 
 						<div class='toggle-group mr18'>
 							<label class='toggle-container'>
-								<input data="7,6,5" checked name='toggle' type='radio'/>
+								<input data="natural_rgb" checked name='toggle' type='radio'/>
 								<div class='btn btn--stroke btn--darken50 toggle'>natural color</div>
 							</label>
 							<label class='toggle-container'>
-								<input data="8,6,7" name='toggle' type='radio' />
+								<input data="false_rgb" name='toggle' type='radio' />
 								<div class='btn btn--stroke btn--darken50 toggle'>false color</div>
 							</label>
 						</div>
 
-						<span>Histogramm cut </span>
+						<span>Histogram cut </span>
 
 						<div class="inputHisto">
 							<input id="minCount" class='input col--2' value='5' />

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
-mapboxgl.accessToken = '{YOUR-MAPBOX-TOKEN}';
-const cbers_services = '{YOUR-ENDPOINT}' //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production/cbers
+mapboxgl.accessToken = 'pk.eyJ1IjoibGlwb3JhY2UiLCJhIjoiY2phY2x2YmF0MGJleTJxb2lmcmJ6a2M4OCJ9.Ujv28eGwfPYxLkKeHCzjzg';
+const cbers_services = 'https://gk4ai2v1m3.execute-api.us-east-1.amazonaws.com/production/cbers'; //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production/cbers
 
 let scope = {};
 
@@ -28,8 +28,8 @@ const buildQueryAndRequestCBERS = (features) => {
     $(".img-display-options .toggle-group input[data='natural_rgb']")[0].nextSibling.nextSibling.innerHTML = sensor[selectedsensor]['button_1']
     $(".img-display-options .toggle-group input[data='false_rgb']")[0].nextSibling.nextSibling.innerHTML = sensor[selectedsensor]['button_2']
     
-    if (map.getSource('cbers-tiles')) map.removeSource('cbers-tiles');
     if (map.getLayer('cbers-tiles')) map.removeLayer('cbers-tiles');
+    if (map.getSource('cbers-tiles')) map.removeSource('cbers-tiles');
 
     const results = [];
 
@@ -102,8 +102,8 @@ const initScene = (sceneID, sceneDate) => {
         $('.cbers-info .l8date').text(sceneDate);
     })
         .fail(() => {
-            if (map.getSource('cbers-tiles')) map.removeSource('cbers-tiles');
             if (map.getLayer('cbers-tiles')) map.removeLayer('cbers-tiles');
+            if (map.getSource('cbers-tiles')) map.removeSource('cbers-tiles');
             $('.cbers-info span').text('');
             $('.cbers-info').addClass('none');
             $('.errorMessage').removeClass('none');
@@ -137,6 +137,7 @@ const clear = () => {
 
   $('.map').removeClass('in');
   $('.right-panel').removeClass('in');
+
   map.resize();
 }
 
@@ -181,6 +182,65 @@ const updateRasterTile = () => {
     });
 };
 
+const updateReferenceGrid = () => {
+
+    if (map.getLayer('cbers-tiles')) map.removeLayer('cbers-tiles');
+    if (map.getSource('cbers-tiles')) map.removeSource('cbers-tiles');
+
+    if (map.getLayer('Grid')) map.removeLayer('Grid');
+    if (map.getLayer('PR_Highlighted')) map.removeLayer('PR_Highlighted');
+    if (map.getLayer('PR_Selected')) map.removeLayer('PR_Selected');
+    if (map.getSource('reference_grid')) map.removeSource('reference_grid');
+
+    map.addSource('reference_grid', {
+        'type': 'vector',
+        'url': sensor[selectedsensor]['url']
+    });
+    
+    map.addLayer({
+        'id': 'Grid',
+        'type': 'fill',
+        'source': 'reference_grid',
+        'source-layer': sensor[selectedsensor]['source_layer'],
+        'paint': {
+            'fill-color': 'hsla(0, 0%, 0%, 0)',
+            'fill-outline-color': {
+                'base': 1,
+                'stops': [
+                    [0, 'hsla(207, 84%, 57%, 0.24)'],
+                    [22, 'hsl(207, 84%, 57%)']
+                ]
+            },
+            'fill-opacity': 1
+        }
+    }, 'admin-2-boundaries-bg');
+
+    map.addLayer({
+        'id': 'PR_Highlighted',
+        'type': 'fill',
+        'source': 'reference_grid',
+        'source-layer': sensor[selectedsensor]['source_layer'],
+        'paint': {
+            'fill-outline-color': '#1386af',
+            'fill-color': '#0f6d8e',
+            'fill-opacity': 0.3
+        },
+        'filter': ['in', 'PATH', '']
+    }, 'admin-2-boundaries-bg');
+
+    map.addLayer({
+        'id': 'PR_Selected',
+        'type': 'line',
+        'source': 'reference_grid',
+        'source-layer': sensor[selectedsensor]['source_layer'],
+        'paint': {
+            'line-color': '#000',
+            'line-width': 1
+        },
+        'filter': ['in', 'PATH', '']
+    }, 'admin-2-boundaries-bg');
+    
+};
 
 const updateMetadata = () => {
     if (!map.getSource('cbers-tiles')) return;
@@ -194,7 +254,8 @@ $(".img-display-options .toggle-group").change(() => {
 
 $(".img-display-options .stoggle-group").change(() => {
     selectedsensor = $(".img-display-options .stoggle-group input:checked").attr("data");
-    clear(); 
+    clear();
+    updateReferenceGrid();
 });
 
 document.getElementById("btn-clear").onclick = () => {
@@ -209,7 +270,7 @@ var map = new mapboxgl.Map({
     center: [-70.50, 0],
     zoom: 3,
     attributionControl: true,
-    minZoom: 3,
+    minZoom: 0,
     maxZoom: 14
 });
 
@@ -265,54 +326,7 @@ map.on('click', (e) => {
 
 map.on('load', () => {
 
-    map.addSource('reference_grid', {
-        'type': 'vector',
-        'url': 'mapbox://vincentsarago.3a75bnx8'
-    });
-
-    map.addLayer({
-        'id': 'Grid',
-        'type': 'fill',
-        'source': 'reference_grid',
-        'source-layer': 'cbers_grid-41mvmk',
-        'paint': {
-            'fill-color': 'hsla(0, 0%, 0%, 0)',
-            'fill-outline-color': {
-                'base': 1,
-                'stops': [
-                    [0, 'hsla(207, 84%, 57%, 0.24)'],
-                    [22, 'hsl(207, 84%, 57%)']
-                ]
-            },
-            'fill-opacity': 1
-        }
-    }, 'admin-2-boundaries-bg');
-
-    map.addLayer({
-        'id': 'PR_Highlighted',
-        'type': 'fill',
-        'source': 'reference_grid',
-        'source-layer': 'cbers_grid-41mvmk',
-        'paint': {
-            'fill-outline-color': '#1386af',
-            'fill-color': '#0f6d8e',
-            'fill-opacity': 0.3
-        },
-        'filter': ['in', 'PATH', '']
-    }, 'admin-2-boundaries-bg');
-
-    map.addLayer({
-        'id': 'PR_Selected',
-        'type': 'line',
-        'source': 'reference_grid',
-        'source-layer': 'cbers_grid-41mvmk',
-        'paint': {
-            'line-color': '#000',
-            'line-width': 1
-        },
-        'filter': ['in', 'PATH', '']
-    }, 'admin-2-boundaries-bg');
-
+    updateReferenceGrid();
     $('.loading-map').addClass('off');
 });
 
@@ -323,26 +337,34 @@ var sensor = {
         'natural_rgb': '7,6,5',
         'false_rgb': '8,6,7',
         'button_1': 'natural color',
-        'button_2': 'false color'
+        'button_2': 'false color',
+        'url': 'mapbox://liporace.2osjfg3d',
+        'source_layer': 'grid-ccb8tn'
     },
     'AWFI': {
         'natural_rgb': '15,14,13',
         'false_rgb': '16,14,15',
         'button_1': 'natural color',
-        'button_2': 'false color'
+        'button_2': 'false color',
+        'url': 'mapbox://liporace.dd0rzf3e',
+        'source_layer': 'awfi_grid-0rixvf'
     },
     'PAN10M': {
         'natural_rgb': '3,4,2',
         'false_rgb': '4,2,3',
         'button_1': 'red,green,nir',
-        'button_2': 'false color'
+        'button_2': 'false color',
+        'url': 'mapbox://liporace.djaooanl',
+        'source_layer': 'pan10m_grid-1pt472'
     },
     'PAN5M': {
         'natural_rgb': '1,1,1',
         'false_rgb': '1,1,1',
         'button_1': 'gray',
-        'button_2': ''
-    }    
+        'button_2': '',
+        'url': 'mapbox://liporace.c52fs3s7',
+        'source_layer': 'pan5m_grid-ccw3gd'
+    }
 };
 
 var selectedsensor = $(".img-display-options .stoggle-group input:checked").attr("data");

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
-mapboxgl.accessToken = 'pk.eyJ1IjoibGlwb3JhY2UiLCJhIjoiY2phY2x2YmF0MGJleTJxb2lmcmJ6a2M4OCJ9.Ujv28eGwfPYxLkKeHCzjzg';
-const cbers_services = 'https://gk4ai2v1m3.execute-api.us-east-1.amazonaws.com/production/cbers'; //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production/cbers
+mapboxgl.accessToken = '{YOUR-MAPBOX-TOKEN}';
+const cbers_services = '{YOUR-ENDPOINT}' //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production/cbers
 
 let scope = {};
 

--- a/viewer/js/app.js
+++ b/viewer/js/app.js
@@ -1,7 +1,7 @@
 'use strict';
 
 mapboxgl.accessToken = '{YOUR-MAPBOX-TOKEN}';
-const cbers_services = 'https://gk4ai2v1m3.execute-api.us-east-1.amazonaws.com/production/cbers' //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production/cbers
+const cbers_services = '{YOUR-ENDPOINT}' //e.g https://xxxxxxxxxx.execute-api.xxxxxxx.amazonaws.com/production/cbers
 
 let scope = {};
 
@@ -23,6 +23,11 @@ const buildQueryAndRequestCBERS = (features) => {
     $('.errorMessage').addClass('none');
     $('.cbers-info').addClass('none');
 
+    // Adjust color combinations buttons for selected sensor
+    $(".img-display-options .toggle-group input[data='natural_rgb']").prop('checked', true);
+    $(".img-display-options .toggle-group input[data='natural_rgb']")[0].nextSibling.nextSibling.innerHTML = sensor[selectedsensor]['button_1']
+    $(".img-display-options .toggle-group input[data='false_rgb']")[0].nextSibling.nextSibling.innerHTML = sensor[selectedsensor]['button_2']
+    
     if (map.getSource('cbers-tiles')) map.removeSource('cbers-tiles');
     if (map.getLayer('cbers-tiles')) map.removeLayer('cbers-tiles');
 
@@ -148,7 +153,7 @@ const updateRasterTile = () => {
     // NOTE: Calling 512x512px tiles is a bit longer but gives a
     // better quality image and reduce the number of tiles requested
 
-    // HACK: Trade-off between quality and speed. Setting source.tileSize to 512 and telling landsat-tiler
+    // HACK: Trade-off between quality and speed. Setting source.tileSize to 512 and telling tiler
     // to get 256x256px reduces the number of lambda calls (but they are faster)
     // and reduce the quality because MapboxGl will oversample the tile.
 
@@ -316,19 +321,27 @@ map.on('load', () => {
 var sensor = {
     'MUX': {
         'natural_rgb': '7,6,5',
-        'false_rgb': '8,6,7'
+        'false_rgb': '8,6,7',
+        'button_1': 'natural color',
+        'button_2': 'false color'
     },
     'AWFI': {
         'natural_rgb': '15,14,13',
-        'false_rgb': '16,14,15'
+        'false_rgb': '16,14,15',
+        'button_1': 'natural color',
+        'button_2': 'false color'
     },
     'PAN10M': {
         'natural_rgb': '3,4,2',
-        'false_rgb': '3,2,4'
+        'false_rgb': '4,2,3',
+        'button_1': 'red,green,nir',
+        'button_2': 'false color'
     },
     'PAN5M': {
         'natural_rgb': '1,1,1',
-        'false_rgb': '1,1,1'
+        'false_rgb': '1,1,1',
+        'button_1': 'gray',
+        'button_2': ''
     }    
 };
 


### PR DESCRIPTION
This is my take on #6 

It is already possible to select the CBERS sensor and visualize it. Most of the changes are in the sample client.

### Todo ###
- [x] Update packaging to use the new rio-tiler and aws-sat-api-py. Currently using local packages.
- [x] Generate new path/row grids for the sensors.
- [x] Check the natural and false rgb for PAN10M.
- [x] Disable RGB selection for PAN5M (single panchromatic band).

PR references:
- https://github.com/mapbox/rio-tiler/pull/43
- https://github.com/RemotePixel/aws-sat-api-py/pull/3